### PR TITLE
Hide template load success output in quiet mode

### DIFF
--- a/pdd/load_prompt_template.py
+++ b/pdd/load_prompt_template.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 from typing import Optional
+import os
 from rich import print
 from pdd.path_resolution import get_default_resolver
 
 def print_formatted(message: str) -> None:
     """Print message with raw formatting tags for testing compatibility."""
     print(message)
+
+def _is_quiet_mode() -> bool:
+    return os.getenv("PDD_QUIET") == "1"
 
 def load_prompt_template(prompt_name: str) -> Optional[str]:
     """
@@ -47,7 +51,8 @@ def load_prompt_template(prompt_name: str) -> Optional[str]:
     try:
         with open(prompt_path, 'r', encoding='utf-8') as file:
             prompt_template = file.read()
-            print_formatted(f"[green]Successfully loaded prompt: {prompt_name}[/green]")
+            if not _is_quiet_mode():
+                print_formatted(f"[green]Successfully loaded prompt: {prompt_name}[/green]")
             return prompt_template
 
     except IOError as e:

--- a/tests/test_load_prompt_template.py
+++ b/tests/test_load_prompt_template.py
@@ -32,6 +32,25 @@ def test_load_prompt_template_success(monkeypatch):
             # Assert that the file was opened correctly
             mock_file.assert_called_once_with(prompt_path, 'r', encoding='utf-8')
 
+def test_load_prompt_template_quiet_suppresses_success_message(monkeypatch, capsys):
+    prompt_name = "example_prompt"
+    expected_content = "This is a sample prompt template."
+
+    monkeypatch.setenv("PDD_PATH", "/fake/project/path")
+    monkeypatch.setenv("PDD_QUIET", "1")
+
+    prompt_path = Path("/fake/project/path") / "prompts" / f"{prompt_name}.prompt"
+
+    with patch.object(Path, 'exists', return_value=True):
+        with patch("builtins.open", mock_open(read_data=expected_content)) as mock_file:
+            result = load_prompt_template(prompt_name)
+
+            assert result == expected_content
+            mock_file.assert_called_once_with(prompt_path, 'r', encoding='utf-8')
+
+    captured = capsys.readouterr()
+    assert "Successfully loaded prompt" not in captured.out
+
 # Test Case 2: PDD_PATH environment variable is not set
 def test_load_prompt_template_missing_pdd_path(monkeypatch, capsys):
     prompt_name = "example_prompt"


### PR DESCRIPTION
﻿## Summary

`--quiet` already sets `PDD_QUIET=1`, and the preprocessing/logging path now respects that env flag. One success message still leaked through `load_prompt_template()`, though, so commands that load prompt templates could print `Successfully loaded prompt: ...` even in quiet mode.

This change keeps the existing public function signature and only suppresses that success line when `PDD_QUIET=1`. Error messages for missing files, IO failures, and invalid input still print normally.

## Checks

- `python -m py_compile pdd/load_prompt_template.py tests/test_load_prompt_template.py`
- `git diff --check`
- direct behavior check for `load_prompt_template()` with and without `PDD_QUIET=1`

I also tried the targeted pytest files, but this checkout does not have the project dependency set installed, so pytest stops during `tests/conftest.py` import with `ModuleNotFoundError: No module named 'litellm'` before it reaches these tests.

Refs #168
